### PR TITLE
fixed formatting errors on spreadsheet install?

### DIFF
--- a/_includes/spreadsheetSetup.html
+++ b/_includes/spreadsheetSetup.html
@@ -1,6 +1,5 @@
 <div id="r"> <!-- Start of 'R' section. -->
   <h3>Spreadsheets</h3>
-
   <p>
     Spreadsheets are useful for data entry and data organization, and 
 some subsetting and sorting of the data as well as getting an overview of the data. To interact with spreadsheets, we can use
@@ -9,11 +8,8 @@ some subsetting and sorting of the data as well as getting an overview of the da
     <a href="http://www.gnumeric.org">Gnumeric</a>, 
     <a href="https://www.openoffice.org">OpenOffice.org</a>, or other programs. 
   Commands may differ a bit between programs, but general ideas for thinking about spreadsheets is the same. 
-
 <p>
 For this lesson, if you don't have a spreadsheet program already, you can use <a href="https://www.libreoffice.org">LibreOffice</a>. It's a free, open source spreadsheet program.
-
-
     <div class="col-md-4">
       <h4 id="windows">Windows</h4>
       <p>
@@ -28,7 +24,6 @@ Your download should begin automatically.
 	    </ul>
       </p>
     </div>
-
     <div class="col-md-4">
       <h4 id="macosx">Mac OS X</h4>
       <p>
@@ -43,28 +38,19 @@ Your download should begin automatically.
             <br>The file <i>LibreOffice_4.4.2_MacOS_x86-64</i> should have been downloaded. Double click on this file, and LibreOffice will be installed. 
             </ul>
       </p>
-
-
     </div>
-    
     <div class="col-md-4">
       <h4 id="linux">Linux</h4>
       <p>
         <ul>
           <li><b>Download the Installer</b>
-        <br>Install LibreOffice by going to the <a href=https://www.libreoffice.\
-org/download/libreoffice-fresh/>installation page</a>. The version for Linux
+        <br>Install LibreOffice by going to the <a href=https://www.libreoffice.org/download/libreoffice-fresh/>installation page</a>. The version for Linux
 should automatically be selected. Click <b>Download Version 4.4.2</b>. You
 will go to a page that asks about a donation, but you don't need to make one.
 Your download should begin automatically.
           <li><b>Install LibreOffice</b>
-            <br>Once the installer is downloaded, double click on it and it shou\
-ld install.
+            <br>Once the installer is downloaded, double click on it and it should install.
             </ul>
       </p>
-
-
-
     </div>
-
 </div> 


### PR DESCRIPTION
There seems to be some kind of hybrid markdown/html formatting going on, specifically: two newlines followed by four space indent creates a markdown code block, revealing the raw html. As a fix, I removed the extra newlines. Also fixed backslashes that were misbehaving.
